### PR TITLE
AT_01.02_003 | <Header> Verify a placeholder text “Search (CTRL+K)" in input field Search box.

### DIFF
--- a/cypress/e2e/headerSearchBox.cy.js
+++ b/cypress/e2e/headerSearchBox.cy.js
@@ -1,0 +1,8 @@
+/// <reference types="cypress"/>
+
+describe('Header Search Box', () => {
+    
+    it('AT_01.02_003 | Verify a placeholder text “Search (CTRL+K)" in input field Search box', function () {
+    cy.get('#search-box').should('have.attr', 'placeholder', 'Search (CTRL+K)')
+    });
+})


### PR DESCRIPTION
https://trello.com/c/I0ta0Zr6/151-at0102003-header-verify-a-placeholder-text-search-ctrlk-in-input-field-search-box