### PR TITLE
AT_01.02_004 | <Header> Verify a placeholder text "Search (Ctrl+K)" input field Search box.

### DIFF
--- a/cypress/e2e/headerSearchBoxMax.cy.js
+++ b/cypress/e2e/headerSearchBoxMax.cy.js
@@ -1,0 +1,8 @@
+/// <reference types="cypress"/>
+
+describe('Header Search Box', () => {
+
+    it('AT_01.02_004 | Verify a placeholder text "Search (Ctrl+K)" input field Search box', function () {
+        cy.get('#search-box').should('have.attr', 'placeholder', 'Search (CTRL+K)')
+     });
+})


### PR DESCRIPTION
https://trello.com/c/NeB445nd/272-at0102004-header-verify-a-placeholder-text-search-ctrlk-input-field-search-box