### PR TITLE
AT_01.02_019| Header> No results appear after input text 

### DIFF
--- a/cypress/e2e/headerSearchBox.cy.js
+++ b/cypress/e2e/headerSearchBox.cy.js
@@ -35,4 +35,10 @@ describe('Header Search Box', () => {
         cy.get('#search-box')
           .should('be.visible')
     });
+
+    it('AT_01.02_019| No results appear after input text in the Search box', () => {
+        cy.get('input.main-search__input').type('text' + '{enter}')
+        cy.get('div.error').should('have.text', 'Nothing seems to match.')
+    });
+
 })


### PR DESCRIPTION
https://trello.com/c/SWt05fc9/706-at0102019-header-no-results-appear-after-input-text-in-the-search-box