### PR TITLE
AT_01.10.004 | Header | Verify that Orange Notifications icon is Visible

### DIFF
--- a/cypress/e2e/verifyNotifacationsBell.cy.js
+++ b/cypress/e2e/verifyNotifacationsBell.cy.js
@@ -5,4 +5,9 @@ describe('Header | Notifications icon', () => {
         cy.get('#visible-am-button').click()
         cy.get('#visible-am-list a[href="/manage"]').should('have.text', 'Manage Jenkins')
     })
+
+    it('AT_01.10.004 | Header | Verify That Orange Notifications icon is Visible', () => {
+        cy.get('#visible-am-insertion span').realHover()
+        cy.get('#visible-am-insertion span').should('have.css','background-color','rgb(255, 152, 0)')
+    })
 })


### PR DESCRIPTION
https://trello.com/c/2rwqfZpn/672-ac0110004-header-verify-that-orange-notifications-icon-is-visible