### PR TITLE
[RF] | POM | AT_01.07_004 | The user’s name should be visible in the header.

### DIFF
--- a/cypress/e2e/headerCredentialsMenuLink.cy.js
+++ b/cypress/e2e/headerCredentialsMenuLink.cy.js
@@ -30,7 +30,7 @@ describe('headerCredentialsMenuLink', () => {
       cy.get('.jenkins-app-bar__content').should('contain', headerCredentials.credentialsPageHeader)
     })
 
-    it('AT_01.07_004 | <Header> The users name should be visible in the header', () => {
+    it.skip('AT_01.07_004 | <Header> The users name should be visible in the header', () => {
       cy.get(`a[href="/user/${login}"]`).should('be.visible');
     });
 

--- a/cypress/e2e/tests/headerAndFooter.cy.js
+++ b/cypress/e2e/tests/headerAndFooter.cy.js
@@ -178,4 +178,10 @@ describe('headerAndFooter', () => {
             .getUserDescriptionText()
             .should('have.text', UserProfilePageData.editDescription);
     });
+
+    it('AT_01.07_004 | The users name should be visible in the header', () => {
+        headerAndFooter
+            .getCurrentUserName()
+            .should('be.visible');
+    });
 })


### PR DESCRIPTION
https://trello.com/c/VwxQ2QHj/1775-rf-pom-at0107004-the-users-name-should-be-visible-in-the-header