### PR TITLE
[RF] | distributedBuildsLink | Verify Link Learn more about distributed builds is redirected to the new window

### DIFF
--- a/cypress/e2e/tests/distributedBuildsLink.cy.js
+++ b/cypress/e2e/tests/distributedBuildsLink.cy.js
@@ -1,18 +1,14 @@
 /// <reference types="cypress"/>
 import HomePage from "../../pageObjects/HomePage";
-import DistributedBuildsLinkPage from "../../pageObjects/DistributedBuildsLinkPage"
 import {distributedBuildsLinkPageUrl} from "../../fixtures/pom_fixtures/distributedBuildsLinkPageData.json"
 
 describe ('distributedBuildsLink', () => {
     const homePage = new HomePage();
-    const distributedBuildsLinkPage = new DistributedBuildsLinkPage;
   
   it ('AT_02.05.09 | Verify Link Learn more about distributed builds is redirected to the new window', () => {
     
     homePage
     .clickLearnMoreAboutDistributedBuildsLink()
-    distributedBuildsLinkPage
     .getDistributedBuildsLinkPageUrl().should('contain', distributedBuildsLinkPageUrl)
-   
   })
 })  


### PR DESCRIPTION
import DistributedBuildsLinkPage is removed as it is not needed

https://trello.com/c/UQywNhYY/1835-rf-distributedbuildslink-verify-link-learn-more-about-distributed-builds-is-redirected-to-the-new-window

