### PR TITLE
POM | AT_07.02_008 | Verify user can sort builds by clicking Time Since

### DIFF
--- a/cypress/e2e/tests/buildHistory.cy.js
+++ b/cypress/e2e/tests/buildHistory.cy.js
@@ -146,5 +146,14 @@ describe('buildHistory', () => {
                     })
             })
     });
+    
+    it('AT_07.02_008 | Verify user can sort builds in descending order by clicking “Time Since”', () => {
+        cy.createFreestyleProject(newItemPageData.freestyleProjectName)
 
+        homePage
+        .createBuildsOfNewProject(newItemPageData.freestyleProjectName, 3) 
+        .clickBuildHistoryLink()
+        .clickTimeSinceBtn()
+        .verifySortBuildsByTimeSience()
+    })
 });

--- a/cypress/pageObjects/BuildHistoryPage.js
+++ b/cypress/pageObjects/BuildHistoryPage.js
@@ -112,7 +112,6 @@ class BuildHistoryPage {
             let expectedData = actualData.slice().sort().reverse()
             expect(actualData).to.have.ordered.members(expectedData)
         })
-        return this
     }
 }
 

--- a/cypress/pageObjects/BuildHistoryPage.js
+++ b/cypress/pageObjects/BuildHistoryPage.js
@@ -19,6 +19,8 @@ class BuildHistoryPage {
     getProjectStatusTableProjectName = () => cy.get('td:nth-child(2) a:first-child')
     getProjectStatusTableProjectBuildNumber = () => cy.get('td:nth-child(2) .jenkins-table__badge')
     getTimeLineProjectNameAndBuild = () => cy.get('.label-event-blue') 
+    getSortHeaderTimeSince = () => cy.get('#projectStatus thead th:nth-child(3) a.sortheader')
+    getProjectStatusTableTimeSinceElements = () => cy.get('table#projectStatus tbody tr td:nth-child(3)')
 
     clickBuildInBuildHistoryCalendar() {
         this.getBuildInBuildHistoryCalendar().click();
@@ -99,6 +101,19 @@ class BuildHistoryPage {
         return cy.wrap (projectNameAndBuildNumberArray)
     };
 
+    clickTimeSinceBtn() {
+    this.getSortHeaderTimeSince().click()
+    return this
+    }
+
+    verifySortBuildsByTimeSience() {
+        this.getProjectStatusTableTimeSinceElements().then(($els) => {
+            let actualData = Cypress.$.makeArray($els).map(($el) => $el.innerText)
+            let expectedData = actualData.slice().sort().reverse()
+            expect(actualData).to.have.ordered.members(expectedData)
+        })
+        return this
+    }
 }
 
 export default BuildHistoryPage;

--- a/cypress/pageObjects/HomePage.js
+++ b/cypress/pageObjects/HomePage.js
@@ -456,6 +456,14 @@ class HomePage {
         this.getHideDescriptionPreview().click();
         return this;
     }
-}
 
+    createBuildsOfNewProject(projectName, buildsNumber) {
+        for(let i = 1; i <= buildsNumber; i++){
+            this.getScheduleBuildBtn(projectName).click();
+            cy.wait(1000);
+    }
+    return this
+    }
+
+}
 export default HomePage;


### PR DESCRIPTION
https://trello.com/c/LWIkc1RL/1729-rf-pom-at0702008-build-history-verify-user-can-sort-builds-in-descending-order-by-clicking-time-since